### PR TITLE
GitHub Actions: Add CI/CD workflow for build, test, and NuGet packaging

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build, Test, and Pack
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - '**'
 
 jobs:
-  build_and_publish:
+  build_and_test:
     runs-on: ubuntu-latest
     
     steps:
@@ -33,10 +33,9 @@ jobs:
     - name: Pack NuGet Package
       run: dotnet pack WikitextParser/WikitextParser.csproj --configuration Release --output ${{ github.workspace }}/nuget_packages --no-build
 
-    - name: Upload Artifact
-      if: steps.pack.outcome == 'success'
+    - name: Upload Package Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: WikitextParser-Package
+        name: WikitextParser-Package-${{ github.ref_name }}-${{ github.sha }}
         path: ${{ github.workspace }}/nuget_packages/*.nupkg
         if-no-files-found: error

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,42 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build all targets
+      run: dotnet build --configuration Release --no-restore
+      
+    - name: Run tests
+      run: dotnet test WikitextParser.Tests --configuration Release --no-build --verbosity normal
+
+    - name: Pack NuGet Package
+      run: dotnet pack WikitextParser/WikitextParser.csproj --configuration Release --output ${{ github.workspace }}/nuget_packages --no-build
+
+    - name: Upload Artifact
+      if: steps.pack.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      with:
+        name: WikitextParser-Package
+        path: ${{ github.workspace }}/nuget_packages/*.nupkg
+        if-no-files-found: error

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,12 +30,18 @@ jobs:
     - name: Run tests
       run: dotnet test WikitextParser.Tests --configuration Release --no-build --verbosity normal
 
+    - name: Sanitize Ref Name for Artifact
+      id: sanitize
+      run: |
+        sanitized_name=$(echo "${{ github.ref_name }}" | tr -s ',"<>:|*?\\/\r\n' '-')
+        echo "name=${sanitized_name}" >> $GITHUB_OUTPUT
+
     - name: Pack NuGet Package
       run: dotnet pack WikitextParser/WikitextParser.csproj --configuration Release --output ${{ github.workspace }}/nuget_packages --no-build
 
     - name: Upload Package Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: WikitextParser-Package-${{ github.ref_name }}-${{ github.sha }}
+        name: WikitextParser-Package-${{ steps.sanitize.outputs.name }}-${{ github.sha }}
         path: ${{ github.workspace }}/nuget_packages/*.nupkg
         if-no-files-found: error


### PR DESCRIPTION
Introduces a GitHub Actions workflow that:
- Restores dependencies, builds the solution, and runs all tests
- Packs the WikitextParser project into a NuGet package on successful test run
- Uploads the .nupkg as a downloadable artifact in the workflow run